### PR TITLE
ELK stack 도입 시도.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.postgresql:postgresql")
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 //	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - ${POSTGRES_VOLUME}
-    networks:
-      - springboot-network
 
   # MongoDB
   mongodb:
@@ -61,6 +59,39 @@ services:
     volumes:
       - ${KAFKA_VOLUME}
 
+  elasticsearch:
+    image: ${ELASTIC_SEARCH_IMAGE}
+    container_name: ${ELASTIC_SEARCH_NAME}
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "${ELASTIC_SEARCH_PORT}:${ELASTIC_SEARCH_PORT}"
+    networks:
+      - elk
+
+  logstash:
+    image: ${LOGSTASH_IMAGE}
+    container_name: ${LOGSTASH_NAME}
+    volumes:
+      - ${LOGSTASH_VOLUME}
+    ports:
+      - "${LOGSTASH_PORT}:${LOGSTASH_PORT}"
+    depends_on:
+      - ${ELASTIC_SEARCH_NAME}
+    networks:
+      - elk
+
+  kibana:
+    image: ${KIBANA_IMAGE}
+    container_name: ${KIBANA_NAME}
+    ports:
+      - "${KIBANA_PORT}:${KIBANA_PORT}"
+    depends_on:
+      - ${ELASTIC_SEARCH_NAME}
+    networks:
+      - elk
+
 networks:
-  springboot-network:
+  elk:
     driver: bridge

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -1,0 +1,19 @@
+input {
+  tcp {
+    port => 5044
+    codec => json
+  }
+}
+
+filter {
+  json {
+    source => "message"
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["elasticsearch:9200"]
+    index => "app-logs-%{+YYYY.MM.dd}"
+  }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<configuration>
+
+  <!-- 콘솔 패턴 설정 -->
+  <appender class="net.logstash.logback.appender.LogstashTcpSocketAppender" name="LOGSTASH">
+    <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+  </appender>
+
+  <!-- 파일 패턴 설정 -->
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Logstash Appender 설정 -->
+  <logger level="DEBUG" name="org.springframework.web"/>
+
+  <!-- 콘솔 로그 설정 -->
+  <property name="FILE_LOG_PATTERN"
+    value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"/>
+
+  <!-- 루트 로거 설정 -->
+  <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} - %msg%n"/>
+
+  <!-- 특정 패키지별 로깅 레벨 설정 -->
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Summary : ELK stack을 도커를 통해서 가장 간단한 형태로 사용을 시도했다. 하지만, 단일 서버 노드와 그 구성으로 인해 서버의 로그 파일 기반 모니터링으로 충분하다.

+ 주요 추가 기능
1. Elastic search, Logstash, Kibana 도입.